### PR TITLE
Propose a vim escape alternative

### DIFF
--- a/vim.markdown
+++ b/vim.markdown
@@ -417,3 +417,10 @@ log in.
 
 ---
 
+# built-in escape alternative
+
+```
+CTRL-C          Quit insert mode, go back to Normal mode.  Do not check for
+                abbreviations.  Does not trigger the |InsertLeave| autocommand
+                event.
+```


### PR DESCRIPTION
Here is a quick way around reaching for escape. I think swapping escape for caps lock is best but this method is useful if caps lock is already re-assigned.
