### PR TITLE
Fixed formatting in vim.markdown

### DIFF
--- a/vim.markdown
+++ b/vim.markdown
@@ -414,6 +414,7 @@ keyboards.
 One common thing to do is swap the caps lock key
 with the escape key because escape is such a
 common key in vim.
+
 ---
 # xmodmap for escape
 
@@ -434,6 +435,7 @@ swapped keys.
 Add this command to your login scripts so that
 each time you log in you won't need to remember to
 run the command every time you log in.
+
 ---
 # built-in escape alternative
 


### PR DESCRIPTION
Added indentation after some sentences to prevent the --- (horizontal rule) from becoming a header.

Example here:
![screen shot 2015-01-09 at 3 24 08 pm](https://cloud.githubusercontent.com/assets/784903/5689109/460d8db4-9814-11e4-872c-ecce20962391.png)
