### PR TITLE
Fix bad layout in "escape..." section

### DIFF
--- a/vim.markdown
+++ b/vim.markdown
@@ -414,6 +414,7 @@ keyboards.
 One common thing to do is swap the caps lock key
 with the escape key because escape is such a
 common key in vim.
+
 ---
 # xmodmap for escape
 


### PR DESCRIPTION
Fix a missing newline between
   "common key in vim"
and
   "---"
which produces unexpected layout for "common key in vim".
